### PR TITLE
Feature/species agnostic

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,4 +24,5 @@ import(S4Vectors)
 importFrom(IRanges, IRanges)
 importFrom(GenomicRanges, GRanges)
 importFrom(GenomicRanges, "mcols<-")
+import(hash)
 

--- a/R/pcf.r
+++ b/R/pcf.r
@@ -106,6 +106,9 @@ pcf <- function(data,pos.unit="bp",arms=NULL,Y=NULL,kmin=5,gamma=40,normalize=TR
 	  	tmpassembly<-read.table(cytoband_file,sep="\t",comment.char = "#",header = FALSE)
 	  }
 	  names(tmpassembly)<-c("chrom","chromStart","chromEnd","name","gieStain")
+	  #restrict assembly to chromosomes in the data frame
+	  tmpassembly<-tmpassembly[tmpassembly$chrom %in% c(keys(tmpChrHash)), ]
+	  tmpassembly<-droplevels(tmpassembly)
 	  for (key in keys(tmpChrHash)) {
      levels(tmpassembly$chrom)[levels(tmpassembly$chrom) == key ] <- tmpChrHash[[key]]
     } 


### PR DESCRIPTION
I have made changes in pcf function to make it species agnostic.
pcf function now accepts user supplied cytoband file.
All the chromosomes are now referred by it's index values assigned before processing.
Original chromosomes names were reassigned to index before returning the results.
Same logic can be applied to other functions wherever required.
Let me know if this makes sense.
